### PR TITLE
12hour inputchange

### DIFF
--- a/src/clockpicker.js
+++ b/src/clockpicker.js
@@ -611,6 +611,7 @@
 					+ this.options.ampmPrefix + this.options.ampmNames[(this.hours < 12 ? 0 : 1)];
 		}
 		this.input.prop('value', value);
+		this.input.triggerHandler('clockpickerdone', [value, last]);
 		if (value !== last) {
 			this.input.triggerHandler('change');
 			if (! this.isInput) {

--- a/src/clockpicker.js
+++ b/src/clockpicker.js
@@ -610,6 +610,7 @@
 			value = leadingZero12Hours(this.hours) + this.options.separator + leadingZero(this.minutes)
 					+ this.options.ampmPrefix + this.options.ampmNames[(this.hours < 12 ? 0 : 1)];
 		}
+		this.input.prop('value', value);
 		if (value !== last) {
 			this.input.triggerHandler('change');
 			if (! this.isInput) {

--- a/src/clockpicker.js
+++ b/src/clockpicker.js
@@ -48,6 +48,10 @@
 		return (num < 10 ? '0' : '') + num;
 	}
 
+	function leadingZero12Hours(num) {
+		return leadingZero(((num + 11) % 12) + 1);
+	}
+
 	// Get a unique id
 	var idCounter = 0;
 	function uniqueId(prefix) {
@@ -69,8 +73,9 @@
 			'<div class="arrow"></div>',
 			'<div class="popover-title">',
 				'<span class="clockpicker-span-hours text-primary"></span>',
-				' : ',
+				'<span class="clockpicker-span-separator"> : </span>',
 				'<span class="clockpicker-span-minutes"></span>',
+				'<span class="clockpicker-span-ampm"></span>',
 			'</div>',
 			'<div class="popover-content">',
 				'<div class="clockpicker-plate">',
@@ -108,7 +113,9 @@
 		this.hoursView = hoursView;
 		this.minutesView = minutesView;
 		this.spanHours = popover.find('.clockpicker-span-hours');
+		this.spanSeparator = popover.find('.clockpicker-span-separator');
 		this.spanMinutes = popover.find('.clockpicker-span-minutes');
+		this.spanAMPM = popover.find('.clockpicker-span-ampm');
 
 		if (! options.autoclose) {
 			// If autoclose is not setted, append a button
@@ -130,6 +137,8 @@
 		// Show or toggle
 		input.on('focus.clockpicker click.clockpicker', $.proxy(this.show, this));
 		addon.on('click.clockpicker', $.proxy(this.toggle, this));
+		// Track input changes
+		input.on('change.clockpicker', $.proxy(this.inputChange, this));
 
 		// Build ticks
 		var tickTpl = $('<div class="clockpicker-tick"></div>'),
@@ -293,7 +302,11 @@
 		align: 'left',       // popover arrow align
 		donetext: '完成',    // done button text
 		autoclose: false,    // auto close when minute is selected
-		vibrate: true        // vibrate the device when dragging clock hand
+		vibrate: true,       // vibrate the device when dragging clock hand
+		show24Hours: true,   // if false set input value and clock title in 12 hour AM/PM format
+		separator: ':',      // separator between hour and minute
+		ampmPrefix: '',      // prefixed to AM/PM string if used on setting input value
+		ampmNames: ['AM', 'PM'] // AM/PM strings to use if show24Hours is false
 	};
 
 	// Show or hide popover
@@ -374,19 +387,8 @@
 			this.isAppended = true;
 		}
 
-		// Get the time
-		var value = ((this.input.prop('value') || this.options['default'] || '') + '').split(':');
-		if (value[0] === 'now') {
-			var now = new Date(+ new Date() + this.options.fromnow);
-			value = [
-				now.getHours(),
-				now.getMinutes()
-			];
-		}
-		this.hours = + value[0] || 0;
-		this.minutes = + value[1] || 0;
-		this.spanHours.html(leadingZero(this.hours));
-		this.spanMinutes.html(leadingZero(this.minutes));
+		// Set the time from input
+		this.setTime();
 
 		// Toggle to hours view
 		this.toggleView('hours');
@@ -412,6 +414,41 @@
 				self.hide();
 			}
 		});
+	};
+
+	// Set time from input
+	ClockPicker.prototype.setTime = function(){
+		// Get the time
+		var value = (($.trim(this.input.prop('value')) || this.options['default'] || '') + '').toLowerCase();
+		var values = value.split(this.options.separator);
+		if (values[0] === 'now') {
+			var now = new Date(+ new Date() + this.options.fromnow);
+			values = [
+				now.getHours(),
+				now.getMinutes()
+			];
+		} else {
+			values[0] = parseInt($.trim(values[0]).substring(0, 2), 10);
+			values[0] = isNaN(values[0]) || values[0] > 23 ? 0 : values[0];
+			if (values.length > 1)  {
+				values[1] = parseInt($.trim(values[1]).substring(0, 2), 10);
+				values[1] = isNaN(values[1]) || values[1] > 59 ? 0 : values[1];
+			}
+			// If in 12 hour AM/PM format parse and convert to 24 hour
+			var isAM = (value.indexOf(this.options.ampmNames[0].toLowerCase()) > -1);
+			var isPM = (value.indexOf(this.options.ampmNames[1].toLowerCase()) > -1);
+			values[0] = ((isAM || isPM) && values[0] === 12 ? 0 : values[0]) + (isPM ? 12 : 0);
+		}
+		this.hours = + values[0] || 0;
+		this.minutes = + values[1] || 0;
+
+		// Set title in 24 hour format if show24Hours true, else in 12 hour AM/PM format
+		this.spanHours.html(this.options.show24Hours ? leadingZero(this.hours) : leadingZero12Hours(this.hours));
+		this.spanSeparator.html(' ' + this.options.separator + ' ');
+		this.spanMinutes.html(leadingZero(this.minutes));
+		if (! this.options.show24Hours) {
+			this.spanAMPM.html(' ' + this.options.ampmNames[this.hours < 12 ? 0 : 1]);
+		}
 	};
 
 	// Hide popover
@@ -523,7 +560,12 @@
 		}
 
 		this[this.currentView] = value;
-		this[isHours ? 'spanHours' : 'spanMinutes'].html(leadingZero(value));
+		if (isHours && ! this.options.show24Hours) {
+			this['spanHours'].html(leadingZero12Hours(value));
+			this.spanAMPM.html(' ' + this.options.ampmNames[this.hours < 12 ? 0 : 1]);
+		} else {
+			this[isHours ? 'spanHours' : 'spanMinutes'].html(leadingZero(value));
+		}
 
 		// If svg is not supported, just add an active class to the tick
 		if (! svgSupported) {
@@ -561,8 +603,13 @@
 	ClockPicker.prototype.done = function() {
 		this.hide();
 		var last = this.input.prop('value'),
-			value = leadingZero(this.hours) + ':' + leadingZero(this.minutes);
-		this.input.prop('value', value);
+			value;
+		if (this.options.show24Hours) {
+			value = leadingZero(this.hours) + this.options.separator + leadingZero(this.minutes);
+		} else {
+			value = leadingZero12Hours(this.hours) + this.options.separator + leadingZero(this.minutes)
+					+ this.options.ampmPrefix + this.options.ampmNames[(this.hours < 12 ? 0 : 1)];
+		}
 		if (value !== last) {
 			this.input.triggerHandler('change');
 			if (! this.isInput) {
@@ -576,6 +623,7 @@
 		this.element.removeData('clockpicker');
 		this.input.off('focus.clockpicker click.clockpicker');
 		this.addon.off('click.clockpicker');
+		this.input.off('change.clockpicker');
 		if (this.isShown) {
 			this.hide();
 		}
@@ -583,6 +631,12 @@
 			$win.off('resize.clockpicker' + this.id);
 			this.popover.remove();
 		}
+	};
+
+	// When input changes, update the time and refresh the view
+	ClockPicker.prototype.inputChange = function() {
+		this.setTime();
+		this.toggleView(this.currentView);
 	};
 
 	// Extends $.fn.clockpicker


### PR DESCRIPTION
Adds 12 hour AM/PM support, enabled by new option "show24Hour" set to false (default true). This and other new options are based on timeEntry by @kbwood (https://github.com/kbwood/timeentry), with which clockpicker works well - see the fiddle http://jsfiddle.net/gitlost/WXD3x/ for an example. The clock hours have been left as is, in 24 hour format - may be confusing.

Also adds tracking input changes with new event handler inputChange(), with setting time from input factored out into a new function, setTime().

Also adds event "clockpickerdone" which is triggered after clockpicker sets the input in done() - generally handy (as mentioned by @vv3d0x in https://github.com/weareoutman/clockpicker/issues/7) and avoids having to listen to "change" in timeEntry case.
