### PR TITLE
12hour inputchange

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,11 @@ if (something) {
 | autoclose | false | auto close when minute is selected |
 | vibrate | true | vibrate the device when dragging clock hand |
 | fromnow | 0 | set default time to * milliseconds from now (using with default = 'now') |
+| immediateset | false | set input as soon as the clock time changes |
+| show24Hours | true | if false set input value and clock title in 12 hour AM/PM format |
+| separator | ':' | separator between hour and minute |
+| ampmPrefix | '' | prefixed to AM/PM string (if used) on setting input value |
+| ampmNames | ['AM', 'PM'] | AM/PM strings to use if show24Hours is false |
 
 ## Operations
 

--- a/index.html
+++ b/index.html
@@ -26,6 +26,9 @@
 	width: 110px;
 	margin-bottom: 10px;
 }
+.input-group.ampm {
+	width: 125px;
+}
 .pull-center {
 	margin-left: auto;
 	margin-right: auto;
@@ -134,6 +137,26 @@ $('.clockpicker').clockpicker();
 &lt;/script&gt;</code></pre>
 	</div>
 	<div class="form-group">
+		<h4>12 hour AM/PM format, immediate set, auto close:</h4>
+		<div class="clearfix">
+			<div class="input-group ampm clockpicker pull-center" data-autoclose="true" data-show24-hours="false" data-immediateset="true">
+				<input type="text" class="form-control" value="01:14PM">
+				<span class="input-group-addon">
+					<span class="glyphicon glyphicon-time"></span>
+				</span>
+			</div>
+		</div>
+		<pre class="hljs-pre"><code class="html">&lt;div class="input-group clockpicker" data-autoclose="true" data-show24-hours="false" data-immediateset="true"&gt;
+	&lt;input type="text" class="form-control" value="13:14"&gt;
+	&lt;span class="input-group-addon"&gt;
+		&lt;span class="glyphicon glyphicon-time"&gt;&lt;/span&gt;
+	&lt;/span&gt;
+&lt;/div&gt;
+&lt;script type="text/javascript"&gt;
+$('.clockpicker').clockpicker();
+&lt;/script&gt;</code></pre>
+	</div>
+	<div class="form-group">
 		<h4>Set options in javascript, instead of <code>data-*</code> :</h4>
 		<div class="input-group clockpicker" data-placement="top" data-align="left" data-donetext="Done">
 			<input type="text" class="form-control" value="18:00">
@@ -226,6 +249,31 @@ $('#check-minutes').click(function(e){
 	<td>fromnow</td>
 	<td>0</td>
 	<td>set default time to * milliseconds from now (using with default = 'now')</td>
+	</tr>
+	<tr>
+	<td>immediateset</td>
+	<td>false</td>
+	<td>set input as soon as the clock time changes</td>
+	</tr>
+	<tr>
+	<td>show24Hours</td>
+	<td>true</td>
+	<td>if false set input value and clock title in 12 hour AM/PM format</td>
+	</tr>
+	<tr>
+	<td>separator</td>
+	<td>':'</td>
+	<td>separator between hour and minute</td>
+	</tr>
+	<tr>
+	<td>ampmPrefix</td>
+	<td>''</td>
+	<td>prefixed to AM/PM string (if used) on setting input value</td>
+	</tr>
+	<tr>
+	<td>ampmNames</td>
+	<td>['AM', 'PM']</td>
+	<td>AM/PM strings to use if show24Hours is false</td>
 	</tr>
 	</tbody>
 	</table>

--- a/jquery.html
+++ b/jquery.html
@@ -47,6 +47,9 @@ code {
 	width: 110px;
 	margin-bottom: 10px;
 }
+.input-group.ampm {
+	width: 125px;
+}
 .pull-center {
 	margin-left: auto;
 	margin-right: auto;
@@ -155,6 +158,26 @@ $('.clockpicker').clockpicker();
 &lt;/script&gt;</code></pre>
 	</div>
 	<div class="form-group">
+		<h4>12 hour AM/PM format, immediate set, auto close:</h4>
+		<div class="clearfix">
+			<div class="input-group ampm clockpicker pull-center" data-autoclose="true" data-show24-hours="false" data-immediateset="true">
+				<input type="text" class="form-control" value="01:14PM">
+				<span class="input-group-addon">
+					<span class="glyphicon glyphicon-time"></span>
+				</span>
+			</div>
+		</div>
+		<pre class="hljs-pre"><code class="html">&lt;div class="input-group clockpicker" data-autoclose="true" data-show24-hours="false" data-immediateset="true"&gt;
+	&lt;input type="text" class="form-control" value="13:14"&gt;
+	&lt;span class="input-group-addon"&gt;
+		&lt;span class="glyphicon glyphicon-time"&gt;&lt;/span&gt;
+	&lt;/span&gt;
+&lt;/div&gt;
+&lt;script type="text/javascript"&gt;
+$('.clockpicker').clockpicker();
+&lt;/script&gt;</code></pre>
+	</div>
+	<div class="form-group">
 		<h4>Set options in javascript, instead of <code>data-*</code> :</h4>
 		<div class="input-group clockpicker" data-placement="top" data-align="left" data-donetext="Done">
 			<input type="text" class="form-control" value="18:00">
@@ -231,6 +254,31 @@ $('#single-input').clockpicker({
 	<td>vibrate</td>
 	<td>true</td>
 	<td>vibrate the device when dragging clock hand</td>
+	</tr>
+	<tr>
+	<td>immediateset</td>
+	<td>false</td>
+	<td>set input as soon as the clock time changes</td>
+	</tr>
+	<tr>
+	<td>show24Hours</td>
+	<td>true</td>
+	<td>if false set input value and clock title in 12 hour AM/PM format</td>
+	</tr>
+	<tr>
+	<td>separator</td>
+	<td>':'</td>
+	<td>separator between hour and minute</td>
+	</tr>
+	<tr>
+	<td>ampmPrefix</td>
+	<td>''</td>
+	<td>prefixed to AM/PM string (if used) on setting input value</td>
+	</tr>
+	<tr>
+	<td>ampmNames</td>
+	<td>['AM', 'PM']</td>
+	<td>AM/PM strings to use if show24Hours is false</td>
 	</tr>
 	</tbody>
 	</table>


### PR DESCRIPTION
Adds 12 hour AM/PM support, enabled by new option "show24Hours" set to false (default true). This and other new 12 hour options are based on timeEntry by @kbwood (https://github.com/kbwood/timeentry), with which clockpicker works well - see the fiddle http://jsfiddle.net/gitlost/WXD3x/ for an example. The clock hours have been left as is, in 24 hour format - may be confusing.

Adds new option "immediateset" that sets the input as soon as the clock time changes, with setting input from time factored out into a new function, setInput(). Makes picking on the hour times a one-click op.

Also adds tracking input changes with new event handler inputChange(), with setting time from input factored out into a new function, getInput(). Useful when using timeEntry.

Also adds event "clockpickerdone" which is triggered after clockpicker sets the input in done() - generally handy (as mentioned by @vv3d0x in #7) and avoids having to listen to "change" in timeEntry case.
