### PR TITLE
Added the getTime method

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,17 @@ if (something) {
 	// Manual operations (after clockpicker is initialized).
 	$('#demo-input').clockpicker('show') // Or hide, remove ...
 			.clockpicker('toggleView', 'minutes');
+
+	// Get the time of single clockpicker
+	var dateObject = $('#demo-input').clockpicker('getTime');
+	console.log(dateObject);
+
+	// Get the time of a clockpicker list
+	$('.clockpicker').clockpicker('getTime', function(dateObject) {
+		// The clockpicker element
+		console.log(this);
+		console.log(dateObject);
+	});
 }
 </script>
 ```
@@ -69,14 +80,14 @@ if (something) {
 
 | Name | Default | Description |
 | ---- | ------- | ----------- |
-| default | '' | default time, 'now' or '13:14' e.g. |
+| default | '' | default time, 'now', Date object or '13:14' e.g. |
 | placement | 'bottom' | popover placement |
 | align | 'left' | popover arrow align |
 | donetext | '完成' | done button text |
 | autoclose | false | auto close when minute is selected |
 | twelvehour | false | enables twelve hour mode with AM & PM buttons |
 | vibrate | true | vibrate the device when dragging clock hand |
-| fromnow | 0 | set default time to * milliseconds from now (using with default = 'now') |
+| fromnow | 0 | set default time to * milliseconds from now (using with default = 'now' or default = Date) |
 | init | | callback function triggered after the colorpicker has been initiated |
 | beforeShow | | callback function triggered before popup is shown |
 | afterShow | | callback function triggered after popup is shown |
@@ -95,6 +106,7 @@ if (something) {
 | hide |   | hide the clockpicker |
 | remove |   | remove the clockpicker (and event listeners) |
 | toggleView | 'hours' or 'minutes' | toggle to hours or minutes view |
+| getTime | Optional callback (Can be used for list of elements) | Returns Date object. (Will call the callback if callback is given) |
 
 ## What's included
 

--- a/src/clockpicker.js
+++ b/src/clockpicker.js
@@ -445,7 +445,7 @@
 		this.hours = + value[0] || 0;
 		this.minutes = + (value[1] + '').replace(/\D/g, '') || 0;
 
-		if (this.twelvehour) {
+		if (this.options.twelvehour) {
 			var period = (value[1] + '').replace(/\d+/g, '').toLowerCase();
 			this.amOrPm = this.hours < 12 || period === 'am' ? 'AM' : 'PM';
 		}


### PR DESCRIPTION
Added the getTime method which returns a Date object, the hours and minutes will be added to today.

``` javascript
// Get the time of single clockpicker
var dateObject = $('#demo-input').clockpicker('getTime');
console.log(dateObject);

// Get the time of a clockpicker list
$('.clockpicker').clockpicker('getTime', function(dateObject) {
    // The clockpicker element
    console.log(this);
    console.log(dateObject);
});
```

Also allows you to add a Date object as the 'default' options.
It will only use the Date object to get the time. It will not update the Date object when the time changes

``` javascript
$('#single-input').clockpicker({
    'default': new Date('Wed, 09 Aug 1995 13:15:00')
});
```
