### PR TITLE
If twelvehour option is used, updates 'AM/PM' states on view

### DIFF
--- a/src/clockpicker.css
+++ b/src/clockpicker.css
@@ -32,8 +32,12 @@
 	line-height: 30px;
 	text-align: center;
 }
-.clockpicker-popover .popover-title span {
+.clockpicker-popover .clockpicker-span-hours,
+.clockpicker-popover .clockpicker-span-minutes {
 	cursor: pointer;
+}
+.clockpicker-popover .clockpicker-span-am-pm {
+	padding: 0 0 0 10px;
 }
 .clockpicker-popover .popover-content {
 	background-color: #f8f8f8;

--- a/src/clockpicker.js
+++ b/src/clockpicker.js
@@ -467,6 +467,8 @@
 		this.spanHours.html(leadingZero(this.hours));
 		this.spanMinutes.html(leadingZero(this.minutes));
 
+		if (this.hours < 12) this.amOrPm = 'AM';
+
 		// Toggle to hours view
 		this.toggleView('hours');
 
@@ -525,6 +527,15 @@
 
 		this.spanHours.toggleClass('text-primary', isHours);
 		this.spanMinutes.toggleClass('text-primary', ! isHours);
+
+		// Select AM/PM
+		if (this.options.twelvehour) {
+			if (this.amOrPm === 'AM') {
+				this.amPmBlock.find('.am-button').trigger('click');
+			} else {
+				this.amPmBlock.find('.pm-button').trigger('click');
+			}
+		}
 
 		// Let's make transitions
 		hideView.addClass('clockpicker-dial-out');

--- a/src/clockpicker.js
+++ b/src/clockpicker.js
@@ -489,7 +489,7 @@
 
 		// Hide when ESC is pressed
 		$doc.on('keyup.clockpicker.' + this.id, function(e){
-			if (e.keyCode === 27) {
+			if (e.keyCode === 27 || e.keyCode === 13) {
 				self.hide();
 			}
 		});


### PR DESCRIPTION
Added a tiny bit of logic to autoselect AM/PM if the twelvehour option is being used.

The current time didn't have AM/PM appended to the end until after the first hour/minute click action.
