### PR TITLE
Stick clockpicker to input-group container

### DIFF
--- a/src/clockpicker.js
+++ b/src/clockpicker.js
@@ -395,32 +395,32 @@
 		// Place the popover
 		switch (placement) {
 			case 'bottom':
-				styles.top = offset.top + height;
+				styles.top = height;
 				break;
 			case 'right':
-				styles.left = offset.left + width;
+				styles.left = width;
 				break;
 			case 'top':
-				styles.top = offset.top - popover.outerHeight();
+				styles.top = -popover.outerHeight();
 				break;
 			case 'left':
-				styles.left = offset.left - popover.outerWidth();
+				styles.left = -popover.outerWidth();
 				break;
 		}
 
 		// Align the popover arrow
 		switch (align) {
 			case 'left':
-				styles.left = offset.left;
+				styles.left = 0;
 				break;
 			case 'right':
-				styles.left = offset.left + width - popover.outerWidth();
+				styles.left = width - popover.outerWidth();
 				break;
 			case 'top':
-				styles.top = offset.top;
+				styles.top = 0;
 				break;
 			case 'bottom':
-				styles.top = offset.top + height - popover.outerHeight();
+				styles.top = height - popover.outerHeight();
 				break;
 		}
 
@@ -441,7 +441,7 @@
 		// Initialize
 		if (! this.isAppended) {
 			// Append popover to body
-			$body = $(document.body).append(this.popover);
+			$body = $(this.element).append(this.popover);
 
 			// Reset position when resize
 			$win.on('resize.clockpicker' + this.id, function(){


### PR DESCRIPTION
This pull request makes that clockpicker is appended to input-group container. It sticks clockpicker to the input field regardless of changing clockpicker position on the page. Currently clockpicker positioning does not work properly when is placed inside bootstrap modal that has a lot of content and requires scrolling.

Recently:
![image](https://cloud.githubusercontent.com/assets/4894611/11169007/c3d25d7e-8ba7-11e5-8ab2-33d948fed8c6.png)

Pull request fix:
![image](https://cloud.githubusercontent.com/assets/4894611/11169008/c78d4c80-8ba7-11e5-9e13-efcba5423b81.png)
