### PR TITLE
Add application entry point to package.json for NPM installs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "email": "wangshenwei@qq.com",
     "url": "http://wangshenwei.com/"
   },
+  "main": "dist/jquery-clockpicker.js",
   "homepage": "http://weareoutman.github.io/clockpicker/",
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR fixes #64 

Will require a `npm publish` after/if this is merged.
